### PR TITLE
Fix GetCounterpartyResp wrong account class and cards field name.

### DIFF
--- a/src/RevolutAPI/RevolutAPI/Models/BusinessApi/Counterparties/GetCounterpartyResp.cs
+++ b/src/RevolutAPI/RevolutAPI/Models/BusinessApi/Counterparties/GetCounterpartyResp.cs
@@ -26,9 +26,8 @@ namespace RevolutAPI.Models.BusinessApi.Counterparties
         [JsonProperty("updated_at")]
         public DateTime UpdatedAt { get; set; }
         [JsonProperty("accounts")]
-        public List<CounterpartyAddress> Accounts { get; set; }
-
-        [JsonProperty("Cards")]
+        public List<CounterpartyAccount> Accounts { get; set; }
+        [JsonProperty("cards")]
         public List<CounterpartyCard> Cards { get; set; }
     }
 }


### PR DESCRIPTION
Accounts property in GetCounterpartyResp class had wrong reference to CounterpartyAddress, but should be CounterpartyAccount. This PR fixes that.